### PR TITLE
Add parameters to the launch file to conditionally start gazebo, rviz, and teleop

### DIFF
--- a/launch/turtlebot3_burger.launch.py
+++ b/launch/turtlebot3_burger.launch.py
@@ -1,153 +1,147 @@
-import datetime
 import logging
 import os
-from os import PathLike
-
 import xacro
-from ament_index_python.packages import get_package_prefix
-from ament_index_python.packages import get_package_share_directory
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, LogInfo, TimerAction
+from ament_index_python.packages import get_package_prefix, get_package_share_directory
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, TimerAction, SetEnvironmentVariable, LogInfo
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration
 
-from launch import LaunchDescription
+
+package_name = "turtlebot3_description"
+robot_name = "turtlebot3"
+
 
 log_level = os.environ.get('LOG_LEVEL', 'INFO').upper()
 logging.basicConfig(level=log_level)
 logging.info('logging configured')
-
-robot_name = 'turtlebot3'
-package_name = 'turtlebot3_description'
-base_xacro_file = 'turtlebot3_burger.urdf.xacro'
-install_dir = get_package_prefix(package_name)
-robot_model_path = os.path.join(get_package_share_directory(package_name))
-xacro_file = os.path.join(robot_model_path, 'urdf', base_xacro_file)
-x = '0.0'
-y = '0.0'
-z = '0.0'
-
-use_sim_time_arg = DeclareLaunchArgument(
-    'use_sim_time',
-    default_value='false',
-    description='Use simulation (sim) time'
-)
-
-start_gazebo_arg = DeclareLaunchArgument(
-    'start_gazebo',
-    default_value='false',
-    description='Launch Gazebo simulation'
-)
-
-start_rviz_arg = DeclareLaunchArgument(
-    'start_rviz',
-    default_value='false',
-    description='Launch RViz'
-)
-
-teleop_type_arg = DeclareLaunchArgument(
-    'teleop_type',
-    default_value='none',
-    description='Start teleop node. Values are keyboard, joystick, or none'
-)
-
-# Get launch configurations
-use_sim_time = LaunchConfiguration('use_sim_time')
-start_gazebo = LaunchConfiguration('start_gazebo')
-start_rviz = LaunchConfiguration('start_rviz')
-teleop_type = LaunchConfiguration('teleop_type')
+logger = logging.getLogger(__name__)
 
 
-def validate_teleop_type(teleop_type: str) -> None:
-    if teleop_type not in ['keyboard', 'joystick', 'none']:
+def validate_teleop_type(teleop_type_val: str) -> None:
+    if teleop_type_val not in ['keyboard', 'joystick', 'none']:
         raise ValueError('Invalid teleop_type. Must be one of: keyboard, joystick, none')
 
 
-def process_xacro_file(xacro_file: PathLike) -> str:
-    # convert XACRO file into URDF
-    logging.debug('parsing xacro doc')
-    doc = xacro.parse(open(xacro_file))
-    xacro.process_doc(doc)
-    return doc.toprettyxml(indent='    ')
+start_gazebo = LaunchConfiguration('start_gazebo')
+start_rviz = LaunchConfiguration('start_rviz')
+teleop_type = LaunchConfiguration('teleop_type')
+world_file = LaunchConfiguration('world_file')
 
 
-def set_gazebo_env_vars():
-    gazebo_models_path = os.path.join(package_name, 'urdf')
-    if 'GAZEBO_MODEL_PATH' in os.environ:
-        path_value = os.environ['GAZEBO_MODEL_PATH'] + ':' + install_dir + '/share' + ':' + gazebo_models_path
-        os.environ['GAZEBO_MODEL_PATH'] = path_value
-    else:
-        os.environ['GAZEBO_MODEL_PATH'] = install_dir + '/share' + ':' + gazebo_models_path
-
-    if 'GAZEBO_PLUGIN_PATH' in os.environ:
-        os.environ['GAZEBO_PLUGIN_PATH'] = os.environ['GAZEBO_PLUGIN_PATH'] + ':' + install_dir + '/lib'
-    else:
-        os.environ['GAZEBO_PLUGIN_PATH'] = install_dir + '/lib'
-
-    logging.debug('GAZEBO MODELS PATH==' + str(os.environ['GAZEBO_MODEL_PATH']))
-    logging.debug('GAZEBO PLUGINS PATH==' + str(os.environ['GAZEBO_PLUGIN_PATH']))
+def start_gazebo_arg():
+    logger.debug('adding start_gazebo arg')
+    return DeclareLaunchArgument(
+        'start_gazebo',
+        default_value='true',
+        description='Launch Gazebo simulation'
+    )
 
 
-def generate_robot_state_publisher_node():
-    urdf_text = process_xacro_file(xacro_file)
-    # save it for debugging
-    timestamp = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
-    outfile_file = os.path.join('/tmp', f'{os.path.splitext(os.path.split(xacro_file)[-1])[0]}-{timestamp}.urdf')
-    with open(outfile_file, 'w') as f:
-        f.write(urdf_text)
+def start_rviz_arg():
+    logger.debug('adding start_rviz arg')
+    return DeclareLaunchArgument(
+        'start_rviz',
+        default_value='false',
+        description='Launch RViz'
+    )
 
+
+def teleop_type_arg():
+    logger.debug('adding teleop_type arg')
+    return DeclareLaunchArgument(
+        'teleop_type',
+        default_value='none',
+        description='Start teleop node. Values are keyboard, joystick, or none'
+    )
+
+
+def world_file_arg():
+    logger.debug('adding world file arg')
+    return DeclareLaunchArgument(
+        'world_file',
+        default_value='worlds/tenBySixteenRoom.world',
+        description='Path to the Gazebo world file'
+    )
+
+
+def robot_state_publisher():
+    logger.debug('adding robot state publisher node')
+    xacro_file_path = os.path.join(get_package_prefix(package_name), 'share', package_name, 'urdf', 'turtlebot3_burger.urdf.xacro')
+    urdf_text = xacro.process_doc(xacro.parse(xacro_file_path)).toprettyxml(indent='    ')
     return Node(package='robot_state_publisher', executable='robot_state_publisher', name='robot_state_publisher',
-                parameters=[{'use_sim_time': use_sim_time, 'robot_description': urdf_text}], output='screen')
+                parameters=[{'use_sim_time': True, 'robot_description': urdf_text}], output='screen')
 
 
-def generate_robot_spawn():
-    logging.debug('robot spawn topic is robot_description')
+def robot_spawn():
+    logger.debug('adding spawn entity node')
     return Node(name='spawn_entity', package='gazebo_ros', executable='spawn_entity.py',
-                arguments=['-entity', robot_name, '-x', x, '-y', y, '-z', z, '-topic', 'robot_description'],
-                parmeters=[{'use_sim_time': use_sim_time}], output='screen')
+                arguments=['-entity', robot_name, '-x', '0.0', '-y', '0.0', '-z', '0.0', '-topic', 'robot_description'],
+                parameters=[{'use_sim_time': True}], output='screen')
 
 
-def generate_static_transform_publisher_node(world_frame):
-    logging.debug('creating static transform')
+def static_transform_publisher():
+    logger.debug('adding static transform publisher node')
     return Node(package='tf2_ros', executable='static_transform_publisher', name='static_transform_publisher_odom',
-                output='screen', emulate_tty=True, arguments=[x, y, z, '0', '0', '0', world_frame, 'base_link'],
-                parameters=[{'use_sim_time': use_sim_time}])
+                output='screen', emulate_tty=True, arguments=['0.0', '0.0', '0.0', '0', '0', '0', 'world', 'base_link'],
+                parameters=[{'use_sim_time': True}])
+
+
+def gazebo_model_path():
+    logger.debug('adding gazebo model env var')
+    gazebo_model_path = [get_package_share_directory(package_name)]
+    if 'GAZEBO_MODEL_PATH' in os.environ:
+        gazebo_model_path.append(os.environ['GAZEBO_MODEL_PATH'])
+    return SetEnvironmentVariable(
+        'GAZEBO_MODEL_PATH', ':'.join(gazebo_model_path),
+        condition=IfCondition(start_gazebo)
+    )
+    
+
+def gazebo_plugin_path():
+    logger.debug('adding gazebo plugin path env var')
+    gazebo_plugin_path = [os.path.join(get_package_prefix(package_name), 'lib')]
+    if 'GAZEBO_PLUGIN_PATH' in os.environ:
+        gazebo_plugin_path.append(os.environ['GAZEBO_PLUGIN_PATH'])
+    return SetEnvironmentVariable(
+        'GAZEBO_PLUGIN_PATH', ':'.join(gazebo_plugin_path),
+        condition=IfCondition(start_gazebo)
+    )
+
+
+def gazebo():
+    logger.debug('adding_gazebo node')
+    return IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [os.path.join(get_package_share_directory('gazebo_ros'), 'launch'), '/gazebo.launch.py']),
+        launch_arguments={'verbose': 'false', 'pause': 'false',
+                          'world': os.path.join(get_package_share_directory(package_name), world_file)}.items(),
+        condition=IfCondition(start_gazebo))
+
+
+def rviz():
+    logger.debug('adding rivz2 node')
+    return Node(package='rviz2', executable='rviz2', name='rviz2', output='screen',
+                arguments=['-d', 'rviz/turtlebot3.rviz'],
+                parameters=[{'use_sim_time': True}],
+                condition=IfCondition(start_rviz))
 
 
 def generate_launch_description():
-    logging.debug('starting generate_launch_description')
-    set_gazebo_env_vars()
-    world_frame = 'world'
-    world_path = 'worlds/tenBySixteenRoom.world'
-    full_world_path = os.path.join(get_package_share_directory(package_name), world_path)
-    logging.info(f'world file: {full_world_path}')
-    logging.debug('creating launch description')
-    launch_description_items = [
-        DeclareLaunchArgument('world', default_value=full_world_path, description='Path to the Gazebo world file'),
-        LogInfo(msg='Launching gazebo.'),
-        IncludeLaunchDescription(PythonLaunchDescriptionSource(
-            [os.path.join(get_package_share_directory('gazebo_ros'), 'launch'), '/gazebo.launch.py']),
-            launch_arguments={'verbose': 'false', 'pause': 'false',
-                              'world': LaunchConfiguration('world'), }.items(),
-            condition=IfCondition(start_gazebo)), ]
-    logging.debug('created base launch config, now appending stuff')
-    delayed_start = TimerAction(actions=[], period=5.0)
-    launch_description_items.append(LogInfo(msg='Gazebo started. Launching robot nodes.'))
-    launch_description_items.append(delayed_start)
-    logging.debug('appended delay start')
-    # start the robots after waiting a bit for gazebo
-    logging.debug(f'defining {robot_name}')
-    state_publisher = generate_robot_state_publisher_node()
-    logging.debug('state publisher added')
-    delayed_start.actions.append(state_publisher)
-    logging.debug('delayed start added')
-    robot_spawn = generate_robot_spawn()
-    logging.debug('robot spawn created')
-    delayed_start.actions.append(robot_spawn)
-    logging.debug('robot spawn added')
-    static_transform = genrate_static_transform_publisher_node(world_frame)
-    logging.debug('static transform created')
-    delayed_start.actions.append(static_transform)
-    logging.debug('static transform added')
-    return LaunchDescription(launch_description_items)
+    logger.debug('creating launch description')
+    return IncludeLaunchDescription(
+        [
+            start_gazebo_arg(),
+            start_rviz_arg(),
+            teleop_type_arg(),
+            world_file_arg(),
+            gazebo(),
+            rviz(),
+            TimerAction(actions=[
+                robot_state_publisher(),
+                robot_spawn(),
+                static_transform_publisher()
+            ], period=5.0)
+        ]
+    )


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] Other (describe):

## Description
The intent of this change is to make the project and particularly the docker file more flexible and more useful. Users will now be able to determine what gets started at launch and can exclude the "extras" if they are not desired or don't fit their use case.

1) This feature updates the launch file:
- Adds a parameter `start_gazebo` to conditionally start gazebo. The default is *true*.
- Adds a parameter `start_rviz` to conditionally start rviz2. The default is *false*.
- Adds a parameter `use_sim_time` to conditionally use the simulation clock instead of the real clock. The default is *false*
- Adds a parameter `teleop_type` that will start one of the teleop nodes in the console where the launch file is run. The default is *none*. Other valid values are *keyboard*, or *joystick*.

The default values are set so that if the defaults are used, the behavior is the same as it was before they were added.

2) Updates the `docker-compose.yaml` file.  The file is updated to allow users to pass the parameters about what to the launch when the container starts.

3) The documentation is updated to provide directions and guidance on specifying these parameters as well as how to use them with the container.

## Related Issue(s)
None

Closes # (issue)
None


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that others can reproduce the tests.

- [ ] Unit tests
- [ ] Integration tests
- [X] Manual testing
- [ ] Other (describe):

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if necessary
- [X] My changes do not generate new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
TBD
