### PR TITLE
fix: copy files specifically so CI, infrastructure changes do not invalidate the docker cache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,10 +7,20 @@ RUN apt-get update && \
     ros-iron-xacro && \
     rm -rf /var/lib/apt/lists/*
 
-COPY . ./ros_ws/src
-COPY docker/start.sh /start.sh
+# don't copy things that might unnecessarily invalidate the cache
+# this can be made cleaner when COPY --exclude is ready.
+# see https://docs.docker.com/reference/dockerfile/#copy---exclude$
+# then it can simply be
+# COPY --exclude docker --exclude .* --exclude CONTRIBUTING.md . /ros_ws/src
 WORKDIR /ros_ws
+COPY launch ./src/launch
+COPY meshes ./src/meshes
+COPY rviz ./src/rviz
+COPY urdf ./src/urdf
+COPY worlds ./src/worlds
+COPY package.xml CMakeLists.txt LICENSE APACHE-2.0-LICENSE README.md ./src/
+
+COPY docker/start.sh /start.sh
 
 RUN bash -c "source /opt/ros/iron/setup.bash && colcon build"
 ENTRYPOINT ["/start.sh"]
-


### PR DESCRIPTION

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (describe):

## Description
So that changed to the CI scripts and other non-code related changes don't invalidate the docker cache, we will explicitly spell out what to copy.



## Related Issue(s)

Closes # (issue)



## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so that others can reproduce the tests.

- [ ] Unit tests
- [ ] Integration tests
- [X] Manual testing
- [ ] Other (describe):

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if necessary
- [X] My changes do not generate new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
